### PR TITLE
fix build errors

### DIFF
--- a/app/templates/lib/antlr4-core/index.js
+++ b/app/templates/lib/antlr4-core/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     // Only one parser and lexer are needed using this example
-    parsers: require('../../dist/grammars/JSONParser'),
-    lexers: require('../../dist/grammars/JSONLexer') ,
+    parsers: require('../../dist/JSONParser'),
+    lexers: require('../../dist/JSONLexer') ,
     lib: require('../../node_modules/antlr4')
 };

--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = {
         ],
     resolve: {
         alias: {
-            'antlr4/index': '../../node_modules/antlr4/index.js'
+            'antlr4/index': '../node_modules/antlr4/index.js'
         },
         modulesDirectories: [
             './node_modules'


### PR DESCRIPTION
The build (calling `webpack`) leads to errors, since modules are not found. I fixed the paths.

**Cause of this issue:**
Generated grammar files are saved directly in directory dist and not in a
subdirectory grammars (see output directory of the ANTLR4 plugin in the
webpack configuration).
